### PR TITLE
Feat/UI: Remove shadow from NavBar, add polkadot background, and add back-to-top button.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --turbo",
     "sync": "tsx src/lib/tweet/sync.ts",
     "build": "next build",
     "start": "next start",

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -12,7 +12,7 @@ export default async function Page() {
     <div>
       <Header />
       <Container>
-        {data.map(async (item) => {
+        {data.map((item) => {
           return (
             <Link key={item.id} href={`/topic/${item.id}`}>
               <div className="px-4 py-8 my-4 bg-white border-b border-b-slate-200 cursor-pointer">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,3 +5,11 @@
 .react-tweet-theme {
   --tweet-body-font-size: 1rem !important;
 }
+
+div[data-theme="light"] {
+  background: linear-gradient(180deg, hsla(0, 0%, 100%, 0) 0, #fff 300px), 0 0 / 20px 20px radial-gradient(#d1d1d1 1px, transparent 0), 10px 10px / 20px 20px radial-gradient(#d1d1d1 1px, transparent 0);
+}
+
+/* div[data-theme="dark"] { */
+/*   background: linear-gradient(180deg, transparent 0, #111 300px), fixed 0 0 / 20px 20px radial-gradient(#313131 1px, transparent 0), fixed 10px 10px / 20px 20px radial-gradient(#313131 1px, transparent 0); */
+/* } */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Plus_Jakarta_Sans } from "next/font/google";
 import "./globals.css";
 import { Navbar } from "@/components/navbar";
+import { BackToTopButton } from "@/components/back-to-top-button";
 
 const jakartaSans = Plus_Jakarta_Sans({ display: "swap", subsets: ["latin"] });
 
@@ -27,6 +28,7 @@ export default async function RootLayout({
           {children}
           {/* <p>Under construction. Please come back later.</p> */}
         </div>
+        <BackToTopButton />
       </body>
     </html>
   );

--- a/src/app/leaderboard/[username]/page.tsx
+++ b/src/app/leaderboard/[username]/page.tsx
@@ -78,7 +78,7 @@ export default async function Page({ params }: Props) {
         ))}
       </div>
 
-      {data.tweets.map((item, index) => (
+      {data.tweets.map((item) => (
         <TweetCard key={item.id} tweet={item.data as Tweet} />
       ))}
     </Container>

--- a/src/app/topic/[id]/page.tsx
+++ b/src/app/topic/[id]/page.tsx
@@ -62,7 +62,7 @@ export default async function Page({ params }: Props) {
       </div>
 
       <div>
-        {tweets.map((tweet, id) => {
+        {tweets.map((tweet) => {
           return <TweetCard key={tweet.id} tweet={tweet.data as Tweet} />;
         })}
       </div>

--- a/src/components/back-to-top-button.tsx
+++ b/src/components/back-to-top-button.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useRef, type MouseEvent } from "react";
+import { ArrowUpFromLineIcon } from "./icon";
+
+type ButtonStatusType = "none" | "active";
+
+export const BackToTopButton = () => {
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const backToTopButtonRevealEvent = () => {
+    const scrollingElement = document.scrollingElement;
+    const scrollPosition = scrollingElement?.scrollTop;
+    const button = buttonRef.current;
+    const status = button?.dataset.status as ButtonStatusType;
+
+    if (scrollPosition === undefined) return;
+
+    if (status === "none" && scrollPosition > 290)
+      return button?.setAttribute("data-status", "active");
+
+    if (status === "active" && scrollPosition < 290)
+      return button?.setAttribute("data-status", "none");
+  }
+  const clickHandler = () => {
+    const scrollingElement = document.scrollingElement;
+    scrollingElement?.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+
+  useEffect(() => {
+    window.addEventListener("scroll", backToTopButtonRevealEvent);
+    return () => window.removeEventListener("scroll", backToTopButtonRevealEvent);
+  })
+
+  return (
+    <button
+      title="Back to top"
+      className="flex justify-center items-start bg-white fixed bottom-9 right-8 md:right-auto md:left-9 p-2 border-2 border-slate-900 rounded-full transition-all data-[status=none]:scale-0 data-[status=none]:translate-y-8 data-[status=active]:scale-1 data-[status=active]:translate-y-0"
+      type="button"
+      onClick={clickHandler}
+      data-status="none" /* "none" | "active" */
+      ref={buttonRef}
+    >
+      <span className="sr-only">Back to top</span>
+      <ArrowUpFromLineIcon />
+    </button>
+  );
+};

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -38,7 +38,7 @@ export const BackButton = ({
 }) => {
   return (
     <Link href={href}>
-      <div className="mb-5 inline-flex border border-gray-300 rounded-md px-3 py-1 text-gray-600 text-sm items-center cursor-pointer hover:bg-gray-100">
+      <div className="mb-5 bg-white inline-flex border border-gray-300 rounded-md px-3 py-1 text-gray-600 text-sm items-center cursor-pointer hover:bg-gray-100">
         <ChevronLeftIcon className="w-2 h-2" />
         <span className="ml-2">Kembali</span>
       </div>

--- a/src/components/container.tsx
+++ b/src/components/container.tsx
@@ -7,13 +7,13 @@ interface ContainerProps {
 
 export const Container = (props: ContainerProps) => {
   return (
-    <div
+    <main
       className={clsx(
         props.className,
         "mx-auto max-w-2xl px-4 sm:px-6 lg:px-8 ",
       )}
     >
       <div className="mx-auto max-w-2xl">{props.children}</div>
-    </div>
+    </main>
   );
 };

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 
 export const Header = () => {
   return (
-    <div className="bg-white px-6 py-12 sm:py-12 lg:px-8">
+    <header className="px-6 py-12 sm:py-12 lg:px-8">
       <div className="mx-auto max-w-2xl text-center">
         <h2 className="mt-2 text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl text-balance">
           Debat Tech Twitter Indonesia
@@ -49,6 +49,6 @@ export const Header = () => {
           </a>
         </div>
       </div>
-    </div>
+    </header>
   );
 };

--- a/src/components/icon.tsx
+++ b/src/components/icon.tsx
@@ -77,9 +77,9 @@ export const SearchIcon = ({ className }: { className?: string }) => (
     viewBox="0 0 24 24"
     fill="none"
     stroke="currentColor"
-    stroke-width="2"
-    stroke-linecap="round"
-    stroke-linejoin="round"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
     className={clsx(className)}
   >
     <circle cx="11" cy="11" r="8" />

--- a/src/components/icon.tsx
+++ b/src/components/icon.tsx
@@ -86,3 +86,23 @@ export const SearchIcon = ({ className }: { className?: string }) => (
     <path d="m21 21-4.3-4.3" />
   </svg>
 );
+
+export const ArrowUpFromLineIcon = ({ className }: { className?: string }) => (
+  // biome-ignore lint/a11y/noSvgWithoutTitle: <explanation>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={clsx(className)}
+  >
+    <path d="M5 3h14" />
+    <path d="m18 13-6-6-6 6" />
+    <path d="M12 7v14" />
+  </svg>
+);

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -11,7 +11,7 @@ export const Navbar = () => {
     domain === "tukar-pikiran.vercel.app" ? "TukarPikiran" : "BakuHantam";
 
   return (
-    <div className="bg-white shadow-md sticky top-0 z-50">
+    <nav className="bg-white border border-y-slate-200 sticky top-0 z-50">
       <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           <div className="flex">
@@ -50,6 +50,6 @@ export const Navbar = () => {
           </div>
         </div>
       </div>
-    </div>
+    </nav>
   );
 };

--- a/src/lib/tweet/data.ts
+++ b/src/lib/tweet/data.ts
@@ -23,7 +23,7 @@ export const getTweetData = () => {
 };
 
 export const checkDuplicateTweets = async () => {
-  const duplicateTweets = await getTweetData()
+  const duplicateTweets = getTweetData()
     .flatMap((d) => {
       return d.tweets.map((t) => t);
     })


### PR DESCRIPTION
I'm removing shadow from `NavBar`, and add polkadot background to the page, I think it's the matter of personal preference but It's more visual pleasing, but I'm sure you'll be agree.
![2024-04-17_13-07](https://github.com/zakiego/baku-hantam/assets/77183252/354e3bff-f442-4944-9d40-0f85a4206f81)

Sometimes some pages is too long, makes it hard to quickly return to the top when I want to go back to the previous page, so I'm adding a back-to-top button.